### PR TITLE
Modify filter recipes to take in a type and a filter option.

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -18,9 +18,11 @@ class User {
   decideToCook(recipe) {
     this.recipesToCook.push(recipe);
   }
-  filterRecipes(type) {
-    return this.favoriteRecipes.filter(recipe => recipe.type.includes(type));
+
+  filterRecipes(type, option) {
+    return this[option].filter(recipe => recipe.type.includes(type));
   }
+  
   searchForRecipe(keyword) {
     return this.favoriteRecipes.filter(recipe => recipe.name.includes(keyword) || recipe.ingredients.includes(keyword));
   }

--- a/test/user-test.js
+++ b/test/user-test.js
@@ -7,12 +7,14 @@ describe('User', function() {
   let user;
   let userInfo;
   let recipe;
+  let recipe2;
 
   beforeEach(function() {
     userInfo = data.users[0];
     user = new User(userInfo)
 
     recipe = {name: 'Chicken Parm', type: ['italian', 'dinner']};
+    recipe2 = {name: 'Pork Tacos', type: ['mexican', 'dinner']};
   });
 
   it('should be a function', function() {
@@ -49,12 +51,19 @@ describe('User', function() {
     expect(user.recipesToCook[0].name).to.equal('Chicken Parm');
   });
 
-  it('should be able to filter recipes by type', function() {
+  it('should be able to filter favoriteRecipes or recipesToCook by type', function() {
     user.saveRecipe(recipe);
-    expect(user.filterRecipes('italian')).to.deep.equal([recipe]);
+    user.saveRecipe(recipe2);
+    user.decideToCook(recipe2);
+
+    expect(user.filterRecipes('italian', 'favoriteRecipes')).to.deep.equal([recipe]);
+    expect(user.filterRecipes('mexican', 'recipesToCook')).to.deep.equal([recipe2]);
   });
 
-  it('should be able to search recipes by name', function() {
+  // How to Test sad paths here. What happens if there are
+  // no matches?
+
+  it('should be able to search recipes by name or ingredient', function() {
     user.saveRecipe(recipe);
     expect(user.searchForRecipe('Chicken Parm')).to.deep.equal([recipe]);
   });

--- a/test/user-test.js
+++ b/test/user-test.js
@@ -51,17 +51,19 @@ describe('User', function() {
     expect(user.recipesToCook[0].name).to.equal('Chicken Parm');
   });
 
-  it('should be able to filter favoriteRecipes or recipesToCook by type', function() {
+  it('should be able to filter favoriteRecipes by type', function() {
     user.saveRecipe(recipe);
-    user.saveRecipe(recipe2);
-    user.decideToCook(recipe2);
 
     expect(user.filterRecipes('italian', 'favoriteRecipes')).to.deep.equal([recipe]);
-    expect(user.filterRecipes('mexican', 'recipesToCook')).to.deep.equal([recipe2]);
+    expect(user.filterRecipes('mexican', 'favoriteRecipes')).to.deep.equal([]);
   });
 
-  // How to Test sad paths here. What happens if there are
-  // no matches?
+  it('should be able to filter recipesToCook by type', function() {
+    user.decideToCook(recipe2);
+
+    expect(user.filterRecipes('italian', 'recipesToCook')).to.deep.equal([]);
+    expect(user.filterRecipes('mexican', 'recipesToCook')).to.deep.equal([recipe2]);
+  });
 
   it('should be able to search recipes by name or ingredient', function() {
     user.saveRecipe(recipe);


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling/UX

### Detailed Description
I updated the filterRecipes() method to take in an extra parameter. The extra parameter will be a string of which property to search for. 

### Why is this change required? What problem does it solve?
This allows the user to filter `favoriteRecipes` or `recipesToCook` by type with the same method.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

### Files modified:
- [X] user.js
- [X] user-test.js

